### PR TITLE
Fix: mixup of . and \w

### DIFF
--- a/_episodes/04-regular-expressions.md
+++ b/_episodes/04-regular-expressions.md
@@ -381,7 +381,7 @@ Open the [swcCoC.md file](https://github.com/LibraryCarpentry/lc-data-intro/tree
 {: .challenge}
 
 > ## Add to what you know
-> The string before the "@" could contain any kind of word character, special character or digit in any combination and length. How would you express this in regex? Hint: often addresses will have a dash (`-`) in them, and the dash is not included in the character expression (`.`). How do you capture this in the expression?
+> The string before the "@" could contain any kind of word character, special character or digit in any combination and length. How would you express this in regex? Hint: often addresses will have a dash (`-`) in them, and the dash is not included in the word character expression (`\w`). How do you capture this in the expression?
 > > ## Solution
 > > ~~~
 > > [\w|.|\d|-]+@


### PR DESCRIPTION
The dash is included in `.`, but not in `\w`
