### PR TITLE
Update 01-introduction.md

### DIFF
--- a/_episodes/01-introduction.md
+++ b/_episodes/01-introduction.md
@@ -27,7 +27,7 @@ Periodically during the sessions we will collect anonymous feedback that will go
 
 ### Where to go for help 
 
-Begin by identifying people on your table who can help: you will all be working from the same material, so someone around you may have mastered the point you are stuck at.
+Begin by identifying people at your table who can help: you will all be working from the same material, so someone around you may have mastered the point you are stuck at.
 
 There are helpers on hand to help if those around you can't. You should all have access to coloured sticky notes: attaching a red sticky note to your laptop indicates that you need help (it might also alert the attention of someone around you!). So, please use them. Most Library Carpentry lessons will require you to follow along whilst your instructor demonstrates a software tool or approach. Sometimes you will fall behind. If you do, raise your red sticky note and ask a helper if we can slow the pace.
 


### PR DESCRIPTION
fixed minor typo replacing "on table" with "at table" (line 30) also recommend replacing "whilst" with "while" (line 32) as I think both are correct by while is more plain language (and I am Canadian so I know it's more common in Britain but I think internationally "whilst" is not commonly used).

Please delete the text below before submitting your contribution. 

---

Thanks for contributing! If this contribution is for instructor training, please send an email to checkout@carpentries.org with a link to this contribution so we can record your progress. You’ve completed your contribution step for instructor checkout just by submitting this contribution.  

Please keep in mind that lesson maintainers are volunteers and it may be some time before they can respond to your contribution. Although not all contributions can be incorporated into the lesson materials, we appreciate your time and effort to improve the curriculum.  If you have any questions about the lesson maintenance process or would like to volunteer your time as a contribution reviewer, please contact Kate Hertweck (k8hertweck@gmail.com).  

---
