### PR TITLE
Use non-breaking spaces in "head rest" exercise

### DIFF
--- a/_episodes/04-regular-expressions.md
+++ b/_episodes/04-regular-expressions.md
@@ -232,7 +232,7 @@ Then test each other on the answers. If you want to check your logic use [regex1
 {: .challenge}
 
 > ## Word boundaries
-> How would you find the whole word `headrest` and or `head rest` but not `head  rest` (that is, with two spaces between `head` and `rest`?
+> How would you find the whole word `headrest` and or `head rest` but not <code>head&nbsp;&nbsp;rest</code> (that is, with two spaces between `head` and `rest`?
 >
 > > ## Solution
 > > ~~~

--- a/_episodes/06-quiz-answers.md
+++ b/_episodes/06-quiz-answers.md
@@ -28,7 +28,7 @@ How do you match the whole words `colour` and `color` (case insensitive)?
 
 - In real life, you *should* only come across the case insensitive variations `colour`, `color`, `Colour`, `Color`, `COLOUR`, and `COLOR` (rather than, say, `coLour`. So one option would be `\b[Cc]olou?r\b|\bCOLOU?R\b`. This can, however, get quickly quite complex. An option we've not discussed is to take advantage of the `/` delimiters and add an ignore case flag: so `/colou?r/i` will match all case insensitive variants of `colour` and `color`.
 
-How would you find the whole-word `headrest` or `head rest` but not `head  rest` (that is, with two spaces between `head` and `rest`?
+How would you find the whole-word `headrest` or `head rest` but not <code>head&nbsp;&nbsp;rest</code> (that is, with two spaces between `head` and `rest`?
 
 - `\bhead ?rest\b`. Note that although `\bhead\s?rest\b` does work, it would also match zero or one tabs or newline characters between `head` and `rest`. In most real world cases it should, however, be fine.
 


### PR DESCRIPTION
It looks like multiple spaces get "squeezed" in the rendering, even within backticked inline code blocks. This change uses `<code>` tags, and within those, two non-breaking spaces (`&nsbp;`) to get the correct rendering.