### PR TITLE
Replace instances of "foobar" with actual words

### DIFF
--- a/_episodes/04-regular-expressions.md
+++ b/_episodes/04-regular-expressions.md
@@ -48,13 +48,13 @@ Then there are:
 - `\w` matches any part of word character (equivalent to `[A-Za-z0-9]`)
 - `\s` matches any space, tab, or newline
 - `\` used to escape the following character when that character is a special character. So, for example, a regular expression that found `.com` would be `\.com` because `.` is a special character that matches any character.
-- `^` asserts the position at the start of the line. So what you put after the caret will only match if they are the first characters of a line. The caret is also known as a circumflex.
-- `$` asserts the position at the end of the line. So what you put before it will only match if they are the last characters of a line.
-- `\b` adds a word boundary. Putting this either side of a word stops the regular expression matching longer variants of words. So:
-	- the regular expression `foobar` will match `foobar` and find `666foobar`, `foobar777`, `8thfoobar8th` et cetera
-	- the regular expression `\bfoobar` will match `foobar` and find `foobar777`
-	- the regular expression `foobar\b` will match `foobar` and find `666foobar`
-	- the regular expression `\bfoobar\b` will find `foobar` but not `666foobar` or `foobar777`
+- `^` is an "anchor" which asserts the position at the start of the line. So what you put after the caret will only match if they are the first characters of a line. The caret is also known as a circumflex.
+- `$` is an "anchor" which asserts the position at the end of the line. So what you put before it will only match if they are the last characters of a line.
+- `\b` asserts that the pattern must match at a word boundary. Putting this either side of a word stops the regular expression matching longer variants of words. So:
+	- the regular expression `mark` will match not only `mark` but also find `marking`, `market`, `unremarkable`, and so on
+	- the regular expression `\bword` will match `word`, `wordless`, and `wordlessly`
+	- the regular expression `comb\b` will match `comb` and `honeycomb` but not `combine`
+	- the regular expression `\brespect\b` will match `respect` but not `respectable` or `disrespectful`
 
 So, what is `^[Oo]rgani.e\b` going to match?
 
@@ -190,7 +190,7 @@ Then test each other on the answers. If you want to check your logic use [regex1
 > > Frence
 > > Franch
 > > ~~~
-> > This will also find words where there are characters either side of the solutions above, such as `Francer`, `foobarFrench`, and `Franch911`.
+> > Note that without an "anchor" such as `^` or `\b`, this will also find strings where there are characters to either side of the regular expression, such as `in French`, `France's`, `French-fried`, and even misspellings such as `Franch` or `Frence`.
 > {: .solution}
 {: .challenge}
 
@@ -204,7 +204,7 @@ Then test each other on the answers. If you want to check your logic use [regex1
 > > Frence
 > > Franch
 > > ~~~
-> > This will also find strings at the end of a line. It will find words where there were characters before these, for example `foobarFrench`.
+> > This will match the pattern only when it appears at the end of a line. It will also find strings with other characters coming _before_ the pattern, for example, `in French` or `faux-French`.
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/04-regular-expressions.md
+++ b/_episodes/04-regular-expressions.md
@@ -190,7 +190,7 @@ Then test each other on the answers. If you want to check your logic use [regex1
 > > Frence
 > > Franch
 > > ~~~
-> > Note that without an "anchor" such as `^` or `\b`, this will also find strings where there are characters to either side of the regular expression, such as `in French`, `France's`, `French-fried`, and even misspellings such as `Franch` or `Frence`.
+> > Note that the way this regular expression is constructed, it will match misspellings such as `Franch` and `Frence`. Lacking an "anchor" such as `^` or `\b`, this will also find strings where there are characters to either side of the regular expression, such as `in French`, `France's`, `French-fried`.
 > {: .solution}
 {: .challenge}
 

--- a/_episodes/05-quiz.md
+++ b/_episodes/05-quiz.md
@@ -26,17 +26,17 @@ Q2. Which of the following matches any space, tab, or newline?
 - B) `\b`
 - C) `$`
 
-Q3. How do you match the string `Foobar` appearing at the beginning of a line?
+Q3. How do you match the string `Confident` appearing at the beginning of a line?
 
-- A) `$Foobar`
-- B) `^Foobar`
-- C) `#Foobar`
+- A) `$Confident`
+- B) `^Confident`
+- C) `#Confident`
 
-Q4. How do you match the word `Foobar` appearing at the beginning of a line?
+Q4. How do you match the word `Confidential` appearing at the beginning of a line?
 
-- A) `^Foobar\d`
-- B) `^Foobar\b`
-- C) `^Foobar\w`
+- A) `^Confidential\d`
+- B) `^Confidential\b`
+- C) `^Confidential\w`
 
 Q5. What does the regular expression `[a-z]` match?
 

--- a/_episodes/06-quiz-answers.md
+++ b/_episodes/06-quiz-answers.md
@@ -14,15 +14,15 @@ keypoints:
 
 What does `Fr[ea]nc[eh]` match?
 
-- this matches `France`, `French`, `Frence`, and `Franch`. It would find words where there were characters either side of these so `Francer`, `foobarFrench`, or `Franch911`.
+- this matches `France`, `French`, in addition to the misspellings `Frence`, and `Franch`. It would also find strings where there were characters to either side of the pattern such as `France's`, `in French`, or `French-fried`.
 
 What does `Fr[ea]nc[eh]$` match?
 
-- this matches `France`, `French`, `Frence`, and `Franch` at the end of a line. It would find words where there were characters before these so `foobarFrench`.
+- this matches `France`, `French`, `Frence`, and `Franch` _only_ at the end of a line. It would also match strings with other characters appearing _before_ the pattern, such as `in French` or `Sino-French`.
 
 What would match the strings `French` and `France` only that appear at the beginning of a line?
 
-- `^France|^French` This would also find words where there were characters after `French` such as `Frenchness`.
+- `^France|^French` This would also find strings with other characters coming after `French`, such as `Frenchness` or `France's economy`.
 
 How do you match the whole words `colour` and `color` (case insensitive)?
 


### PR DESCRIPTION
* introduces the term "anchor" to describe the `^` and `$` metacharacters, since that's sometimes what they're referred to in the documentation for regular expression libraries
* uses "match" more consistently  than "find" in the word boundary examples
    * some RE libraries (notably the Python programming language) have different connotations for "match" (match the entire input string exactly, as if it had `^` and `$` anchors) and "search" (match anywhere in the input string)
    * using two different words ("match" and "find") to mean the same thing here in the LC course materials might cause confusion
* closes #113