### PR TITLE
make lesson suitable for teaching with locally-built (serverless) pages

### DIFF
--- a/_extras/about.md
+++ b/_extras/about.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: About
-permalink: /about/
 ---
 {% include carpentries.html %}

--- a/_extras/discuss.md
+++ b/_extras/discuss.md
@@ -1,7 +1,5 @@
 ---
-layout: page
 title: Discussion
-permalink: /discuss/
 ---
 There are many ways to discuss Library Carpentry lessons:
 

--- a/_extras/figures.md
+++ b/_extras/figures.md
@@ -1,6 +1,4 @@
 ---
-layout: page
 title: Figures
-permalink: /figures/
 ---
 {% include all_figures.html %}

--- a/_extras/guide.md
+++ b/_extras/guide.md
@@ -1,7 +1,5 @@
 ---
-layout: page
-title: "Instructor Notes"
-permalink: /guide/
+title: Instructor Notes
 ---
 
 ____
@@ -21,7 +19,7 @@ ____
 To teach regular expressions, instructors have used:
 
 - [slides](https://github.com/LibraryCarpentry/lc-data-intro/blob/gh-pages/files/regexslides.pdf) to quiz the audience on examples.
-- Pen and paper, to work through exercises before using a tool and to explain that there can be multiple answers to the same question. 
+- Pen and paper, to work through exercises before using a tool and to explain that there can be multiple answers to the same question.
 - Whiteboard with text examples and quized participants on regex approaches.
 - Online tools such as: [Regxr](https://regexr.com/), [regex101](https://regex101.com/), [rexegper](http://regexper.com/), [myregexp](http://myregexp.com/), or whichever service you prefer.
 - Used quiz/exercise files in [https://github.com/LibraryCarpentry/lc-data-intro/tree/gh-pages/files](https://github.com/LibraryCarpentry/lc-data-intro/tree/gh-pages/files).

--- a/index.md
+++ b/index.md
@@ -1,8 +1,9 @@
 ---
 layout: lesson
 root: .
+permalink: index.html
 ---
-This Library Carpentry lesson introduces people with library- and information-related roles to working with data using regular expressions. The lesson provides background on the regular expression language and how it can be used to match and extract text and to clean data. 
+This Library Carpentry lesson introduces people with library- and information-related roles to working with data using regular expressions. The lesson provides background on the regular expression language and how it can be used to match and extract text and to clean data.
 
 > ## Teaching this lesson
 >

--- a/reference.md
+++ b/reference.md
@@ -1,7 +1,5 @@
 ---
 layout: reference
-root: .
-
 ---
 
 ## Regular Expression Cheat Sheet
@@ -20,4 +18,3 @@ root: .
 - `?` matches when the preceding character appears zero or one time.
 - `{VALUE}` matches the preceding character the number of times define by VALUE; ranges can be specified with the syntax `{VALUE,VALUE}`.
 - `|` means or.
-

--- a/setup.md
+++ b/setup.md
@@ -1,11 +1,7 @@
 ---
-layout: page
 title: Setup
-root: .
 ---
 
 ### This lesson does not require any special setup.
 
 --------
-
-


### PR DESCRIPTION
See discussion here for more background: https://github.com/datacarpentry/datacarpentry.github.io/issues/542

In short, some Carpentries lessons use the path `/guide/` for their Instructor Notes page and others use `/guide/index.html` (the default defined in `_config.yml`). This PR removes permalinks with a trailing slash from the YAML front matter of the Instructor Notes (`_extras/guide.md`) and other Extras files, consistent with new lessons created with [the lesson template](https://github.com/carpentries/styles/). Although there's no functional difference in the online versions of the lesson pages, pages with a trailing slash in the permalink will result in **broken links in the version of the lesson built locally**. We'd like local builds to be usable e.g. in workshops taking place at locations with limited or unreliable Internet access. 

Keeping the paths to these files consistent will also help us avoid broken links on the [Library Carpentry Lessons page](https://librarycarpentry.org/lessons/), and ensure that equivalent paths in new lessons created with the template are consistent with previously-developed lessons like this one.

I did a sweep through the lesson and found no internal links that need to be adjusted as part of this PR. If and when this is merged, I'll also make sure the link on https://librarycarpentry.org/lessons/ to the Instructor Notes page isn't broken, and make another sweep through the lesson pages too. 

Finally, I also removed the `layout` field from several pages, as the default layout is already set for Episodes and Extras pages in `_config.yml`.