### PR TITLE
02-match-extract-strings: Fix solution and typos in Finish the expression

### DIFF
--- a/_episodes/02-match-extract-strings.md
+++ b/_episodes/02-match-extract-strings.md
@@ -122,10 +122,10 @@ Open the [swcCoC.md file](https://github.com/LibraryCarpentry/lc-data-intro/tree
 {: .challenge}
 
 > ## Finish the expression
-> The string after the "@" could contain any kind of word character, special character or digit in any combination and length as well as the dash. In addition, we know that it will with some characters after a period (`.`). Most common domain names have two or three characters, but many more are now possible. Find the latest list [here](http://stats.research.icann.org/dns/tld_report/). What expression would capture this? Hint: the `.` is also a regex expression, so you'll have to use the escape `\` to express a literal period. Note: for the string after the period, we did not try to match a character, since those rarely appear in the characters after the period at the end of an email address.
+> The string after the "@" could contain any kind of word character, special character or digit in any combination and length as well as the dash. In addition, we know that it will have some characters after a period (`.`). Most common domain names have two or three characters, but many more are now possible. Find the latest list [here](http://stats.research.icann.org/dns/tld_report/). What expression would capture this? Hint: the `.` is also a metacharacter, so you will have to use the escape `\` to express a literal period. Note: for the string after the period, we did not try to match a `-` character, since those rarely appear in the characters after the period at the end of an email address.
 > > ## Solution
 > > ~~~
-> >   [\w.-]+\.[\w]{2,3} OR [\w.-]+\.[\w]
+> > [\w.-]+\.\w{2,3} OR [\w.-]+\.\w+
 > > ~~~
 > > See the previous exercise for the explanation of the expression up to the `+`
 > >


### PR DESCRIPTION
This PR is to fix the solution and typos in the Finish the expression challenge. At some point the last `+` was removed from the solution. Also, there is no need to put the `\w` after the literal `.` in square brackets since it is only one option.

As a side note, in challenges where you give hints, you could do them as dropdowns to give people a chance to solve the challenge without them e.g.:
```
> > ## Hint
> > The `.` is also a metacharacter, so you will have to use the escape `\`
> > to express a literal period.
```
![hint_dropdown](https://user-images.githubusercontent.com/6740390/146265630-d15726a7-96b5-4466-b419-4c7a9fe427e2.png)

I did not include the Hint as a dropdown in this PR, since that is not how you are doing hints generally.
