### PR TITLE
update zenodo json for lesson release

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -2,133 +2,108 @@
   "contributors": [
     {
       "type": "Editor",
-      "name": "Carmi Cronje",
-      "orcid": "0000-0003-2736-6267"
-    },
-    {
-      "type": "Editor",
-      "name": "Paul Pival",
-      "orcid": "0000-0002-1685-0590"
+      "name": "Angela M. Zoss",
+      "orcid": "0000-0002-9647-597X"
     },
     {
       "type": "Editor",
       "name": "Shari Laster",
       "orcid": "0000-0001-9099-1474"
-    },
-    {
-      "type": "Editor",
-      "name": "Anton Angelo",
-      "orcid": "0000-0002-2265-1299"
     }
   ],
   "creators": [
+    {
+      "name": "Christopher Erdmann",
+      "orcid": "0000-0003-2554-180X"
+    },
+    {
+      "name": "Shari Laster",
+      "orcid": "0000-0001-9099-1474"
+    },
+    {
+      "name": "Paul R. Pival"
+    },
+    {
+      "name": "Cornelia Cronje",
+      "orcid": "0000-0003-2736-6267"
+    },
+    {
+      "name": "bkmgit"
+    },
+    {
+      "name": "Phil Reed",
+      "orcid": "0000-0002-4479-715X"
+    },
+    {
+      "name": "Kathryn M. Miller",
+      "orcid": "0000-0001-8005-089X"
+    },
+    {
+      "name": "Annajiat Alim Rasel",
+      "orcid": "0000-0003-0198-3734"
+    },
     {
       "name": "James Baker",
       "orcid": "0000-0002-2682-6922"
     },
     {
-      "name": "Christopher Erdmann",
-      "orcid": "0000-0003-2554-180X"
+      "name": "Jannetta Steyn",
+      "orcid": "0000-0002-0231-9897"
+    },
+    {
+      "name": "morskyjezek",
+      "orcid": "0000-0003-2617-0166"
+    },
+    {
+      "name": "Kevin Ernst"
+    },
+    {
+      "name": "kylamj",
+      "orcid": "0000-0002-8795-1372"
+    },
+    {
+      "name": "Lauren Ko"
+    },
+    {
+      "name": "Meghan Landry",
+      "orcid": "0000-0002-2353-3956"
+    },
+    {
+      "name": "Varachkina"
+    },
+    {
+      "name": "Amber York",
+      "orcid": "0000-0002-5133-5842"
+    },
+    {
+      "name": "Benjamin Tovar",
+      "orcid": "0000-0002-5294-2281"
+    },
+    {
+      "name": "Berika Williams"
+    },
+    {
+      "name": "Kevin Ernst"
+    },
+    {
+      "name": "Lynda K"
+    },
+    {
+      "name": "Martin Czygan"
+    },
+    {
+      "name": "Sarah Swanz"
+    },
+    {
+      "name": "Steven J. Baskauf",
+      "orcid": "0000-0003-4365-3135"
     },
     {
       "name": "Tim Dennis",
       "orcid": "0000-0001-6632-3812"
     },
     {
-      "name": "Elizabeth Lisa McAulay"
-    },
-    {
-      "name": "Shari Laster"
-    },
-    {
-      "name": "François Michonneau",
-      "orcid": "0000-0002-9092-966X"
-    },
-    {
-      "name": "Kunal Marwaha",
-      "orcid": "0000-0001-9084-6971"
-    },
-    {
-      "name": "Paul R. Pival"
-    },
-    {
-      "name": "Katrin Leinweber",
-      "orcid": "0000-0001-5135-5758"
-    },
-    {
-      "name": "Alex Volkov"
-    },
-    {
-      "name": "Dan Michael O. Heggø"
-    },
-    {
-      "name": "fdsayre"
-    },
-    {
-      "name": "lsult"
-    },
-    {
-      "name": "Saskia Scheltjens"
-    },
-    {
-      "name": "yvonnemery"
-    },
-    {
-      "name": "Alexander Mendes"
-    },
-    {
-      "name": "Angus Taggart"
-    },
-    {
-      "name": "Belinda Weaver"
-    },
-    {
-      "name": "BertrandCaron"
-    },
-    {
-      "name": "Bianca Peterson",
-      "orcid": "0000-0001-6927-9159"
-    },
-    {
-      "name": "Christopher Edsall"
-    },
-    {
-      "name": "Chuck McAndrew"
-    },
-    {
-      "name": "Dan Michael Heggø",
-      "orcid": "0000-0002-6189-5958"
-    },
-    {
-      "name": "Felix Hemme",
-      "orcid": "0000-0001-7754-782X"
-    },
-    {
-      "name": "Janice Chan"
-    },
-    {
-      "name": "Jeffrey Oliver",
-      "orcid": "0000-0003-2160-1086"
-    },
-    {
-      "name": "Jeremy Guillette"
-    },
-    {
-      "name": "Jodi Schneider"
-    },
-    {
-      "name": "Jonah Duckles",
-      "orcid": "0000-0002-8985-3119"
-    },
-    {
-      "name": "Katherine Koziar",
-      "orcid": "0000-0003-0505-7973"
-    },
-    {
-      "name": "PH03N1X007"
-    },
-    {
-      "name": "remerjohnson"
+      "name": "cnancarrow"
     }
   ],
   "license": {


### PR DESCRIPTION
updating the `.zenodo.json` with metadata about contributors since last release, in preparation for the infrastructure transition.