### PR TITLE
Clarify issues links in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,12 +26,13 @@ introduce yourself and to meet some of our community members.
 
 2. If you have a [GitHub][github] account, or are willing to [create
    one][github-join], but do not know how to use Git, you can report problems
-   or suggest improvements by [creating an issue][issues]. This allows us to
-   assign the item to someone and to respond to it in a threaded discussion.
+   or suggest improvements by [creating an issue][repo-issues]. This allows us
+   to assign the item to someone and to respond to it in a threaded discussion.
 
 3. If you are comfortable with Git, and would like to add or change material,
    you can submit a pull request (PR). Instructions for doing this are
-   [included below](#using-github).
+   [included below](#using-github). For inspiration about changes that need to
+   be made, check out the [list of open issues][issues] across the Carpentries.
 
 Note: if you want to build the website locally, please refer to [The Workbench
 documentation][template-doc].
@@ -49,8 +50,8 @@ There are many ways to contribute, from writing new exercises and improving
 existing ones to updating or filling in the documentation and submitting [bug
 reports][issues] about things that do not work, are not clear, or are missing.
 If you are looking for ideas, please see [the list of issues for this
-repository][repo], or the issues for [Data Carpentry][dc-issues], [Library
-Carpentry][lc-issues], and [Software Carpentry][swc-issues] projects.
+repository][repo-issues], or the issues for [Data Carpentry][dc-issues],
+[Library Carpentry][lc-issues], and [Software Carpentry][swc-issues] projects.
 
 Comments on issues and reviews of pull requests are just as welcome: we are
 smarter together than we are on our own. **Reviews from novices and newcomers
@@ -102,6 +103,7 @@ media, slack, newsletters, and email lists. You can also [reach us by
 email][contact].
 
 [repo]: https://example.com/FIXME
+[repo-issues]: https://example.com/FIXME/issues
 [contact]: mailto:team@carpentries.org
 [cp-site]: https://carpentries.org/
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry
@@ -111,7 +113,7 @@ email][contact].
 [github]: https://github.com
 [github-flow]: https://guides.github.com/introduction/flow/
 [github-join]: https://github.com/join
-[how-contribute]: https://egghead.io/series/how-to-contribute-to-an-open-source-project-on-github
+[how-contribute]: https://egghead.io/courses/how-to-contribute-to-an-open-source-project-on-github
 [issues]: https://carpentries.org/help-wanted-issues/
 [lc-issues]: https://github.com/issues?q=user%3ALibraryCarpentry
 [swc-issues]: https://github.com/issues?q=user%3Aswcarpentry

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ community listed at <https://carpentries.org/connect/> including via social
 media, slack, newsletters, and email lists. You can also [reach us by
 email][contact].
 
-[repo]: https://example.com/FIXME
+[repo]: https://github.com/LibraryCarpentry/lc-data-intro
 [repo-issues]: https://github.com/LibraryCarpentry/lc-data-intro/issues
 [contact]: mailto:team@carpentries.org
 [cp-site]: https://carpentries.org/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ media, slack, newsletters, and email lists. You can also [reach us by
 email][contact].
 
 [repo]: https://example.com/FIXME
-[repo-issues]: https://example.com/FIXME/issues
+[repo-issues]: https://github.com/LibraryCarpentry/lc-data-intro/issues
 [contact]: mailto:team@carpentries.org
 [cp-site]: https://carpentries.org/
 [dc-issues]: https://github.com/issues?q=user%3Adatacarpentry


### PR DESCRIPTION
This pull request is being submitted to all repos that have been converted to Workbench, so that they reflect a recent update in the Workbench template. The change is probably appropriate for your repository, but you may disagree. I encourage you to look at a description of the problem it fixes found in [this comment](https://github.com/datacarpentry/organization-genomics/issues/154#issuecomment-1577040104) of [this issue](https://github.com/datacarpentry/organization-genomics/issues/154).

You will still need to replace `example.com/FIXME` in the [repo] and [repo-issues] link targets with this repository.

It additionally fixes the broken [how-contribute] link.
