### PR TITLE
Fix mismatch in exercise

### DIFF
--- a/episodes/01-regular-expressions.md
+++ b/episodes/01-regular-expressions.md
@@ -113,7 +113,7 @@ So, what are these going to match?
 
 :::::::::::::::::::::::::::::::::::::::  challenge
 
-## `^[Oo]rgani.e\\w\*`
+## `^[Oo]rgani.e\w*`
 
 What will the regular expression `^[Oo]rgani.e\w*` match?
 


### PR DESCRIPTION
This exercise has a mismatch between the exercise name and the regular expression that is used in the exercise. The solution matches the regular expression that is used in the exercise, but not the exercise name (which has an extra `\`). This PR removes the extra `\` from the exercise name so that it matches the exercise and the solution. 


<img width="762" alt="Screenshot 2023-10-16 at 9 50 36 AM" src="https://github.com/LibraryCarpentry/lc-data-intro/assets/19176319/b2407db2-5298-4587-b270-a65c13cc998f">
